### PR TITLE
Fix len_seconds when the converter was used

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -74,7 +74,7 @@ fn main() {
 		conv.until_exhausted().map(|v| v[0]).collect()
 	};
 
-	let len_seconds = audio_buf.len() as f64 / desc.sample_rate() as f64;
+	let len_seconds = audio_buf.len() as f64 / SAMPLE_RATE as f64;
 
 	let decoded_time = Instant::now();
 


### PR DESCRIPTION
I noticed that the times being shown were off. This fixes them.

I think the other examples probably need the same fix.