### PR TITLE
Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/RustAudio/deepspeech-rs"
 version = "0.5.0"
 authors = ["est31 <MTest31@outlook.com>"]
 readme = "README.md"
+edition = "2018"
 
 [dev-dependencies]
 audrey = "0.2"

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,6 +1,3 @@
-extern crate deepspeech;
-extern crate audrey;
-
 use std::path::Path;
 use std::env::args;
 use std::fs::File;

--- a/examples/client_extended.rs
+++ b/examples/client_extended.rs
@@ -1,6 +1,3 @@
-extern crate deepspeech;
-extern crate audrey;
-
 use std::path::Path;
 use std::env::args;
 use std::fs::File;

--- a/examples/client_simple.rs
+++ b/examples/client_simple.rs
@@ -1,6 +1,3 @@
-extern crate deepspeech;
-extern crate audrey;
-
 use std::path::Path;
 use std::env::args;
 use std::fs::File;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,6 @@
 Bindings to the DeepSpeech library
 */
 
-extern crate libc;
-extern crate deepspeech_sys;
-
 use std::ffi::CStr;
 use std::fmt;
 use std::path::Path;

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -6,6 +6,7 @@ documentation = "https://docs.rs/deepspeech"
 repository = "https://github.com/RustAudio/deepspeech-rs"
 version = "0.5.0"
 authors = ["est31 <MTest31@outlook.com>"]
+edition = "2018"
 
 include = ["deepspeech/native_client/deepspeech.h", "/src/**",
 	"/build.rs", "/LICENSE", "Cargo.toml"]

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -1,5 +1,3 @@
-extern crate bindgen;
-
 use std::env;
 use std::path::PathBuf;
 


### PR DESCRIPTION
Wanted to try out `deepspeech-rs`, but noticed it was still 2015 edition. Quick fix :-)