### PR TITLE
Automatically search for model in dir for examples

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -29,26 +29,28 @@ fn main() {
 	let audio_file_path = args().nth(2)
 		.expect("Please specify an audio file to run STT on");
 	let dir_path = Path::new(&model_dir_str);
-	let mut graph_name: String = String::from("output_graph.pb");
-	let mut scorer_name: Option<String> = None;
+	let mut graph_name: Box<Path> = dir_path.join("output_graph.pb").into_boxed_path();
+	let mut scorer_name: Option<Box<Path>> = None;
 	// search for model in model directory
 	for file in dir_path.read_dir().expect("Specified model dir is not a dir") {
 		if let Ok(f) = file {
-			if f.file_type().unwrap().is_file() {
-				let file_name = f.file_name().into_string().unwrap();
-				if file_name.ends_with(".pb") || file_name.ends_with(".pbmm") {
-					graph_name = file_name;
-				} else if file_name.ends_with(".scorer") {
-					scorer_name = Some(file_name);
+			let file_path = f.path();
+			if file_path.is_file() {
+				if let Some(ext) = file_path.extension() {
+					if ext == "pb" || ext == "pbmm" {
+						graph_name = file_path.into_boxed_path();
+					} else if ext == "scorer" {
+						scorer_name = Some(file_path.into_boxed_path());
+					}
 				}
 			}
 		}
 	}
-	let mut m = Model::load_from_files(&dir_path.join(&graph_name)).unwrap();
+	let mut m = Model::load_from_files(&graph_name).unwrap();
 	// enable external scorer if found in the model folder
 	if let Some(scorer) = scorer_name {
-		println!("Using external scorer `{}`", scorer);
-		m.enable_external_scorer(&dir_path.join(&scorer)).unwrap();
+		println!("Using external scorer `{}`", scorer.to_str().unwrap());
+		m.enable_external_scorer(&scorer).unwrap();
 	}
 
 	let initialized_time = Instant::now();

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -29,7 +29,27 @@ fn main() {
 	let audio_file_path = args().nth(2)
 		.expect("Please specify an audio file to run STT on");
 	let dir_path = Path::new(&model_dir_str);
-	let mut m = Model::load_from_files(&dir_path.join("output_graph.pb")).unwrap();
+	let mut graph_name: String = String::from("output_graph.pb");
+	let mut scorer_name: Option<String> = None;
+	// search for model in model directory
+	for file in dir_path.read_dir().expect("Specified model dir is not a dir") {
+		if let Ok(f) = file {
+			if f.file_type().unwrap().is_file() {
+				let file_name = f.file_name().into_string().unwrap();
+				if file_name.ends_with(".pb") || file_name.ends_with(".pbmm") {
+					graph_name = file_name;
+				} else if file_name.ends_with(".scorer") {
+					scorer_name = Some(file_name);
+				}
+			}
+		}
+	}
+	let mut m = Model::load_from_files(&dir_path.join(&graph_name)).unwrap();
+	// enable external scorer if found in the model folder
+	if let Some(scorer) = scorer_name {
+		println!("Using external scorer `{}`", scorer);
+		m.enable_external_scorer(&dir_path.join(&scorer)).unwrap();
+	}
 
 	let initialized_time = Instant::now();
 	println!("Model initialized in {:?}.", initialized_time - start);

--- a/examples/client_extended.rs
+++ b/examples/client_extended.rs
@@ -36,26 +36,28 @@ fn main() {
 	let audio_file_path = args().nth(2)
 		.expect("Please specify an audio file to run STT on");
 	let dir_path = Path::new(&model_dir_str);
-	let mut graph_name: String = String::from("output_graph.pb");
-	let mut scorer_name: Option<String> = None;
+	let mut graph_name: Box<Path> = dir_path.join("output_graph.pb").into_boxed_path();
+	let mut scorer_name: Option<Box<Path>> = None;
 	// search for model in model directory
 	for file in dir_path.read_dir().expect("Specified model dir is not a dir") {
 		if let Ok(f) = file {
-			if f.file_type().unwrap().is_file() {
-				let file_name = f.file_name().into_string().unwrap();
-				if file_name.ends_with(".pb") || file_name.ends_with(".pbmm") {
-					graph_name = file_name;
-				} else if file_name.ends_with(".scorer") {
-					scorer_name = Some(file_name);
+			let file_path = f.path();
+			if file_path.is_file() {
+				if let Some(ext) = file_path.extension() {
+					if ext == "pb" || ext == "pbmm" {
+						graph_name = file_path.into_boxed_path();
+					} else if ext == "scorer" {
+						scorer_name = Some(file_path.into_boxed_path());
+					}
 				}
 			}
 		}
 	}
-	let mut m = Model::load_from_files(&dir_path.join(&graph_name)).unwrap();
+	let mut m = Model::load_from_files(&graph_name).unwrap();
 	// enable external scorer if found in the model folder
 	if let Some(scorer) = scorer_name {
-		println!("Using external scorer `{}`", scorer);
-		m.enable_external_scorer(&dir_path.join(&scorer)).unwrap();
+		println!("Using external scorer `{}`", scorer.to_str().unwrap());
+		m.enable_external_scorer(&scorer).unwrap();
 	}
 
 	let audio_file = File::open(audio_file_path).unwrap();

--- a/examples/client_extended.rs
+++ b/examples/client_extended.rs
@@ -36,7 +36,27 @@ fn main() {
 	let audio_file_path = args().nth(2)
 		.expect("Please specify an audio file to run STT on");
 	let dir_path = Path::new(&model_dir_str);
-	let mut m = Model::load_from_files(&dir_path.join("output_graph.pb")).unwrap();
+	let mut graph_name: String = String::from("output_graph.pb");
+	let mut scorer_name: Option<String> = None;
+	// search for model in model directory
+	for file in dir_path.read_dir().expect("Specified model dir is not a dir") {
+		if let Ok(f) = file {
+			if f.file_type().unwrap().is_file() {
+				let file_name = f.file_name().into_string().unwrap();
+				if file_name.ends_with(".pb") || file_name.ends_with(".pbmm") {
+					graph_name = file_name;
+				} else if file_name.ends_with(".scorer") {
+					scorer_name = Some(file_name);
+				}
+			}
+		}
+	}
+	let mut m = Model::load_from_files(&dir_path.join(&graph_name)).unwrap();
+	// enable external scorer if found in the model folder
+	if let Some(scorer) = scorer_name {
+		println!("Using external scorer `{}`", scorer);
+		m.enable_external_scorer(&dir_path.join(&scorer)).unwrap();
+	}
 
 	let audio_file = File::open(audio_file_path).unwrap();
 	let mut reader = Reader::new(audio_file).unwrap();

--- a/examples/client_simple.rs
+++ b/examples/client_simple.rs
@@ -27,26 +27,28 @@ fn main() {
 	let audio_file_path = args().nth(2)
 		.expect("Please specify an audio file to run STT on");
 	let dir_path = Path::new(&model_dir_str);
-	let mut graph_name: String = String::from("output_graph.pb");
-	let mut scorer_name: Option<String> = None;
+	let mut graph_name: Box<Path> = dir_path.join("output_graph.pb").into_boxed_path();
+	let mut scorer_name: Option<Box<Path>> = None;
 	// search for model in model directory
 	for file in dir_path.read_dir().expect("Specified model dir is not a dir") {
 		if let Ok(f) = file {
-			if f.file_type().unwrap().is_file() {
-				let file_name = f.file_name().into_string().unwrap();
-				if file_name.ends_with(".pb") || file_name.ends_with(".pbmm") {
-					graph_name = file_name;
-				} else if file_name.ends_with(".scorer") {
-					scorer_name = Some(file_name);
+			let file_path = f.path();
+			if file_path.is_file() {
+				if let Some(ext) = file_path.extension() {
+					if ext == "pb" || ext == "pbmm" {
+						graph_name = file_path.into_boxed_path();
+					} else if ext == "scorer" {
+						scorer_name = Some(file_path.into_boxed_path());
+					}
 				}
 			}
 		}
 	}
-	let mut m = Model::load_from_files(&dir_path.join(&graph_name)).unwrap();
+	let mut m = Model::load_from_files(&graph_name).unwrap();
 	// enable external scorer if found in the model folder
 	if let Some(scorer) = scorer_name {
-		println!("Using external scorer `{}`", scorer);
-		m.enable_external_scorer(&dir_path.join(&scorer)).unwrap();
+		println!("Using external scorer `{}`", scorer.to_str().unwrap());
+		m.enable_external_scorer(&scorer).unwrap();
 	}
 
 	let audio_file = File::open(audio_file_path).unwrap();

--- a/examples/client_simple.rs
+++ b/examples/client_simple.rs
@@ -27,7 +27,27 @@ fn main() {
 	let audio_file_path = args().nth(2)
 		.expect("Please specify an audio file to run STT on");
 	let dir_path = Path::new(&model_dir_str);
-	let mut m = Model::load_from_files(&dir_path.join("output_graph.pb")).unwrap();
+	let mut graph_name: String = String::from("output_graph.pb");
+	let mut scorer_name: Option<String> = None;
+	// search for model in model directory
+	for file in dir_path.read_dir().expect("Specified model dir is not a dir") {
+		if let Ok(f) = file {
+			if f.file_type().unwrap().is_file() {
+				let file_name = f.file_name().into_string().unwrap();
+				if file_name.ends_with(".pb") || file_name.ends_with(".pbmm") {
+					graph_name = file_name;
+				} else if file_name.ends_with(".scorer") {
+					scorer_name = Some(file_name);
+				}
+			}
+		}
+	}
+	let mut m = Model::load_from_files(&dir_path.join(&graph_name)).unwrap();
+	// enable external scorer if found in the model folder
+	if let Some(scorer) = scorer_name {
+		println!("Using external scorer `{}`", scorer);
+		m.enable_external_scorer(&dir_path.join(&scorer)).unwrap();
+	}
 
 	let audio_file = File::open(audio_file_path).unwrap();
 	let mut reader = Reader::new(audio_file).unwrap();


### PR DESCRIPTION
I've updated the examples so that they iterate through the contents of the model directory, looking for `.pb` and `.pbmm` file extensions. This is instead of assuming that the model is called `output_graph.pb` (with new releases they're usually called `deepspeech-{version}-models.pbmm` but that's more work to keep up to date), which is not ideal.

Since the examples are now already searching through the whole directory, I added in searching for an external scorer in the model directory as well (`.scorer` extension). The external scorer seems to have better accuracy, so it's a nice-to-have but not strictly necessary.

This also sort of fixes #35 , except this PR is on master and tested against v0.9.0 instead.

Love the project! Thanks for your hard work.