### PR TITLE
Add .tflite support for model file search in examples

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -39,7 +39,7 @@ fn main() {
 			let file_path = f.path();
 			if file_path.is_file() {
 				if let Some(ext) = file_path.extension() {
-					if ext == "pb" || ext == "pbmm" {
+					if ext == "pb" || ext == "pbmm" || ext == "tflite" {
 						graph_name = file_path.into_boxed_path();
 					} else if ext == "scorer" {
 						scorer_name = Some(file_path.into_boxed_path());

--- a/examples/client_extended.rs
+++ b/examples/client_extended.rs
@@ -46,7 +46,7 @@ fn main() {
 			let file_path = f.path();
 			if file_path.is_file() {
 				if let Some(ext) = file_path.extension() {
-					if ext == "pb" || ext == "pbmm" {
+					if ext == "pb" || ext == "pbmm" || ext == "tflite" {
 						graph_name = file_path.into_boxed_path();
 					} else if ext == "scorer" {
 						scorer_name = Some(file_path.into_boxed_path());

--- a/examples/client_simple.rs
+++ b/examples/client_simple.rs
@@ -37,7 +37,7 @@ fn main() {
 			let file_path = f.path();
 			if file_path.is_file() {
 				if let Some(ext) = file_path.extension() {
-					if ext == "pb" || ext == "pbmm" {
+					if ext == "pb" || ext == "pbmm" || ext == "tflite" {
 						graph_name = file_path.into_boxed_path();
 					} else if ext == "scorer" {
 						scorer_name = Some(file_path.into_boxed_path());


### PR DESCRIPTION
This is a small change as a result of the discussion in PR #37 , since I didn't add `.tflite` support when I initially implemented the file searching in the examples.


Again, thanks for the project! I've had fun writing Rust code to turn on my VR lighthouses by yelling at my computer :)